### PR TITLE
Update to Python3

### DIFF
--- a/robot_player/dxl_interface.py
+++ b/robot_player/dxl_interface.py
@@ -9,8 +9,8 @@ __status__ = "Prototype"
 
 
 import ctypes
-import dxl.dynamixel_functions as dynamixel
-from dxl.dxl_control_table import DXLPRO, MX106, MX106_P1, MX28
+from .dxl import dynamixel_functions as dynamixel
+from .dxl.dxl_control_table import DXLPRO, MX106, MX106_P1, MX28
 from collections import OrderedDict
 
 # data Byte Length
@@ -46,7 +46,7 @@ class DxlOptions(object):
 
         # if motor_ids is just a single list, then put it inside another list for it
         if len(motor_ids) == 1 and not isinstance(motor_ids[0], list):
-            print "motor_ids is a single list!"
+            print("motor_ids is a single list!")
             motor_ids = [motor_ids]
 
         for port, ids, motor_type in zip(ports, motor_ids, motor_types):
@@ -117,7 +117,7 @@ class DxlInterface(object):
         for d in dxl_ports:
             d.port_num = dynamixel.portHandler(d.device_name)
             self.device.append(d)
-        print self.device
+        print(self.device)
 
         # initialize packet handler
         dynamixel.packetHandler()
@@ -141,7 +141,7 @@ class DxlInterface(object):
                 self.id_to_port[m_id] = d
                 self.motor_id.append(m_id)
 
-        print self.id_to_port
+        print(self.id_to_port)
 
 
 
@@ -170,7 +170,7 @@ class DxlInterface(object):
                 dxl_error = dynamixel.getLastRxPacketError(d.port_num, d.protocol_version )
                 if dxl_comm_result != COMM_SUCCESS:
                     print(dynamixel.getTxRxResult(d.protocol_version , dxl_comm_result))
-                    print "Motor id " + str(m_id) + " was not found!"
+                    print("Motor id " + str(m_id) + " was not found!")
                     continue
                 elif dxl_error != 0:
                     print(dynamixel.getRxPacketError(d.protocol_version , dxl_error))
@@ -197,7 +197,7 @@ class DxlInterface(object):
                                         DXLPRO.L54_50_S290_R,
                                         DXLPRO.L54_30_S400_R,
                                         ]:
-                    print DXLPRO
+                    print(DXLPRO)
 
                     ctrl_table = DXLPRO
                     resolution = DXLPRO.resolution[motor_model_no]
@@ -206,10 +206,10 @@ class DxlInterface(object):
                     ctrl_table = MX28
                     resolution = MX28.resolution
                 else:
-                    print "motor_model not found!"
+                    print("motor_model not found!")
                     quit()
                 d.motor[m_id] = {"model_no":motor_model_no, "ctrl_table":ctrl_table, "resolution":resolution}
-                print "motor_model_no:" + str(motor_model_no)
+                print("motor_model_no:" + str(motor_model_no))
 
     def setup_sync_functions(self):
         self.setup_group_sync_write('GOAL_POSITION', 4)
@@ -220,8 +220,8 @@ class DxlInterface(object):
         # self.setup_group_sync_write('GOAL_CURRENT', 4)
         # self.setup_group_sync_read('PRESENT_CURRENT', 4)
         for d in self.device:
-            print "gw_GOAL_POSITION {}".format(d.gw_GOAL_POSITION)
-            print "gr_PRESENT_POSITION {}".format(d.gr_PRESENT_POSITION)
+            print("gw_GOAL_POSITION {}".format(d.gw_GOAL_POSITION))
+            print("gr_PRESENT_POSITION {}".format(d.gr_PRESENT_POSITION))
 
     def setup_group_sync_write(self, parameter, parameter_data_len):
         """
@@ -233,7 +233,7 @@ class DxlInterface(object):
         """
 
         for d in self.device:
-            print "d.port_num {}".format(d.port_num)
+            print("d.port_num {}".format(d.port_num))
             gw_id = dynamixel.groupSyncWrite(d.port_num,
                                                     d.protocol_version,
                                                     getattr(d.ctrl_table, parameter),

--- a/robot_player/motion_manager.py
+++ b/robot_player/motion_manager.py
@@ -292,17 +292,17 @@ def player_arg_parser(filename):
 #         MM.initialize()
 #         MM.set_all_command_position([0, 0, 0, 0, 0, 0, 0])
 #         for i in xrange(100):
-#             print MM.get_all_current_position()
+#             print(MM.get_all_current_position())
 #             MM.wait(dt)
 #
 #         MM.set_all_command_position([pi / 10, pi / 10, pi / 10, pi / 10, pi / 10, pi / 10, pi / 10, ])
-#         for i in xrange(100):
-#             print MM.get_all_current_position()
+#         for i in range(100):
+#             print(MM.get_all_current_position())
 #             MM.wait(dt)
 #
 #         MM.set_all_command_position([0, 0, 0, 0, 0, 0, 0])
-#         for i in xrange(100):
-#             print MM.get_all_current_position()
+#         for i in range(100):
+#             print(MM.get_all_current_position())
 #             MM.wait(dt)
 
 

--- a/robot_player/timer_test.py
+++ b/robot_player/timer_test.py
@@ -1,6 +1,6 @@
 import time
 import threading
-import Queue
+import queue
 
 stop_flag = threading.Event()
 dt_list = []
@@ -16,7 +16,7 @@ def drummer(freq, signal_flag, stop_flag, q):
         q.put(counter)
         counter += 1
 
-    print "closing timer"
+    print("closing timer")
 
 
 
@@ -25,7 +25,7 @@ if __name__ == '__main__':
     from matplotlib import pyplot as plt
     dt = 16 # milliseconds
     freq = 1000.0//dt
-    q = Queue.Queue()
+    q = queue.Queue()
     control_clock_flag = threading.Event()
     stop_flag = threading.Event()
     t = threading.Thread(target=drummer, args=(freq, control_clock_flag, stop_flag, q))
@@ -40,7 +40,7 @@ if __name__ == '__main__':
         dt_list.append(time.time() - start_time)
         control_clock_flag.clear()
         counter += 1
-        print q.get()
+        print(q.get())
 
     stop_flag.set()
 

--- a/robot_player/vrep/vrep.py
+++ b/robot_player/vrep/vrep.py
@@ -48,12 +48,12 @@ try:
     libfullpath = os.path.join(os.path.dirname(__file__), 'remoteApi' + file_extension)
     libsimx = ct.CDLL(libfullpath)
 except:
-    print ('----------------------------------------------------')
-    print ('The remoteApi library could not be loaded. Make sure')
-    print ('it is located in the same folder as "vrep.py", or')
-    print ('appropriately adjust the file "vrep.py"')
-    print ('----------------------------------------------------')
-    print ('')
+    print('----------------------------------------------------')
+    print('The remoteApi library could not be loaded. Make sure')
+    print('it is located in the same folder as "vrep.py", or')
+    print('appropriately adjust the file "vrep.py"')
+    print('----------------------------------------------------')
+    print('')
 
 #ctypes wrapper prototypes 
 c_GetJointPosition          = ct.CFUNCTYPE(ct.c_int32,ct.c_int32, ct.c_int32, ct.POINTER(ct.c_float), ct.c_int32)(("simxGetJointPosition", libsimx))

--- a/robot_player/vrep/vrep.py
+++ b/robot_player/vrep/vrep.py
@@ -31,7 +31,7 @@ import struct
 import sys
 import os
 import ctypes as ct
-from vrep_const import *
+from .vrep_const import  *
 
 #load library
 libsimx = None

--- a/robot_player/vrep_interface.py
+++ b/robot_player/vrep_interface.py
@@ -98,7 +98,7 @@ class VrepInterface(object):
             self.read_accelerometer(initialize=True) #(operationMode=vrep.simx_opmode_blocking)
 
     def stop(self):
-        print "Ending communication with VREP..."
+        print("Ending communication with VREP...")
         self.print_to_statusbar("Ending communication with client " + str(self._sim_Client_ID))
         vrep.simxStopSimulation(self._sim_Client_ID, vrep.simx_opmode_blocking)
         vrep.simxFinish(-1)
@@ -107,7 +107,7 @@ class VrepInterface(object):
         vrep.simxAddStatusbarMessage(self._sim_Client_ID, msg, vrep.simx_opmode_oneshot)
 
     def wait(self, timesteps_to_wait):
-        for i in xrange(timesteps_to_wait):
+        for i in range(timesteps_to_wait):
             self.send_command()
 
     def get_object_position(self, object_handle, base_handle=-1):
@@ -194,10 +194,10 @@ class VrepInterface(object):
         # setup joint velocities
         for j in new_joint:
             if j['joint_type'] == VrepInterface.JOINT_TYPE_REVOLUTE:
-                print "revolute_joint"
+                print("revolute_joint")
                 j['joint_target_velocity'] = self.revolute_joint_torque_control_max_speed
             elif j['joint_type'] == VrepInterface.JOINT_TYPE_PRISMATIC:
-                print "prismatic_joint"
+                print("prismatic_joint")
                 j['joint_target_velocity'] = self.prismatic_joint_torque_control_max_speed
             else:
                 raise Exception("can't control a joint that isn't revolute or prismatic")
@@ -321,7 +321,7 @@ class VrepInterface(object):
         return self.get_joint_velocity(self.motor_id)
 
     def set_all_joint_effort(self, commands, send=True):
-        # print "setting joint effort"
+        # print("setting joint effort")
         self.set_joint_effort(self.motor_id, commands, send)
 
     def get_all_joint_effort(self, send=True):

--- a/tests/dxl_double_chain_test.py
+++ b/tests/dxl_double_chain_test.py
@@ -22,7 +22,7 @@ def test_set_command_position():
         for pl in position_list:
             mm.set_command_position([1,2,3,4], pl)
             mm.wait(2.5)
-            print mm.get_all_current_position()
+            print(mm.get_all_current_position())
 
             get_curr_pos = mm.get_current_position([1, 2]) + mm.get_current_position([3, 4])
             get_all_curr_pos = mm.get_all_current_position()
@@ -36,7 +36,7 @@ def test_set_all_command_position():
         for pl in position_list:
             mm.set_all_command_position(pl)
             mm.wait(2.5)
-            print mm.get_all_current_position()
+            print(mm.get_all_current_position())
 
             get_curr_pos = mm.get_current_position([1, 2]) + mm.get_current_position([3, 4])
             get_all_curr_pos = mm.get_all_current_position()

--- a/tests/dxl_single_chain_test.py
+++ b/tests/dxl_single_chain_test.py
@@ -23,11 +23,11 @@ with MotionManager(motor_id, dt=dt, options=dxl_opts) as mm:
     mm.set_all_command_position([1,1])
     mm.wait(3)
     assert (np.allclose(mm.get_all_current_position(), np.array([1, 1]), atol=.1))
-    print mm.get_all_current_position()
+    print(mm.get_all_current_position())
 
     # move back
     mm.set_all_command_position([0,0])
     mm.wait(3)
     mm.get_all_current_position()
     assert(np.allclose(mm.get_all_current_position(),np.array([0,0]),atol=.1))
-    print mm.get_all_current_position()
+    print(mm.get_all_current_position())

--- a/tests/test_double_joint.py
+++ b/tests/test_double_joint.py
@@ -25,7 +25,7 @@ with MotionManager(motor_id, dt, VrepOptions(joint_prefix="joint")) as mm:
     assert(np.allclose(pos,[-1,-2]))
 
     # joint velocity
-    print mm.get_joint_velocity([1,2])
+    print(mm.get_joint_velocity([1,2]))
     assert(mm.get_joint_velocity([1,2]) == mm.get_all_joint_velocity())
 
     # switch to force controlled tests

--- a/tests/test_single_joint.py
+++ b/tests/test_single_joint.py
@@ -8,8 +8,8 @@ with MotionManager(motor_id, dt, options=VrepOptions()) as mm:
 
     for i in range(100):
         mm.set_all_joint_effort([-100], send=True)
-        print mm.get_all_joint_effort()
+        print(mm.get_all_joint_effort())
 
     for i in range(100):
         mm.set_joint_effort([1], [70], send=True)
-        print mm.get_all_joint_effort()
+        print(mm.get_all_joint_effort())


### PR DESCRIPTION
Here is the compatibility update for Python3. The changes are nothing big, mostly just adding parentheses to print statements.

Had to change the syntax for a couple of imports but they work the same way.

In Python3 xrange no longer exists. The Python3 range is equivalent to Python2 xrange, so I made that change.

I tested the single and double joint simulations in vrep and everything works like before.

**update**: I have also made changes to the dxl tests and the timer_test files. Same fixes with changing print statements. For timer_test, the queue package changed it's name from a capital Queue to lower case queue.